### PR TITLE
updated to current runtime

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs12.x
   stage: dev
   region: us-east-1
   iamRoleStatements:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: updated severless.yaml to use current nodejs12.x runtime instead of depracated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
